### PR TITLE
give SmartOS/sunos5 the correct CONFIG_DIR

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -75,6 +75,8 @@ if CONFIG_DIR is None:
         CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
     elif 'netbsd' in __PLATFORM:
         CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'pkg', 'etc', 'salt')
+    elif 'sunos5' in __PLATFORM:
+        CONFIG_DIR = os.path.join(ROOT_DIR, 'opt', 'local', 'etc', 'salt')
     else:
         CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
 


### PR DESCRIPTION
Fixes #22634 "Default CONFIG_DIR on SmartOS is wrong in salt/syspaths.py"